### PR TITLE
Mock backend with session storage

### DIFF
--- a/src/components/LoginPageComponent.jsx
+++ b/src/components/LoginPageComponent.jsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { setUserInfoCookie } from '../services/CookieService';
-import axios from 'axios';
 import { authenticateUser } from '../authentication/auth';
 
 import '../styles/LoginPageComponentStyle.css'

--- a/src/components/RegisterComponent.jsx
+++ b/src/components/RegisterComponent.jsx
@@ -1,7 +1,6 @@
 import React, {useState} from 'react';
 import {Link, useNavigate} from 'react-router-dom';
 import {registerUser} from '../authentication/auth';
-import axios from 'axios';
 
 import '../styles/LoginPageComponentStyle.css';
 import {setUserInfoCookie} from "../services/CookieService";

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -1,28 +1,19 @@
-
-import axios from 'axios';
-
-const labResultBaseUrl = process.env.REACT_APP_LABRESULT_BASE_URL || '';
-const patientBaseUrl = process.env.REACT_APP_PATIENT_BASE_URL || '';
-
-const apiUrl = `${labResultBaseUrl}/labresult/register`;
-const apiUrlForPatients = `${patientBaseUrl}/patients/register`;
+import {storeLabResult, storePatient} from './SessionApi';
 
 export const sendEventToApi = async (event: any) => {
     try {
-        const response = await axios.post(apiUrl, event);
-        console.log('Event sent successfully:', response.data);
-
+        await storeLabResult(event);
+        console.log('Event stored locally');
     } catch (error) {
-        console.error('Error sending event:', error);
-
+        console.error('Error storing event:', error);
     }
 };
 
 export const sendPatientToApi = async (patient: any) => {
     try {
-        const response = await axios.post(apiUrlForPatients, patient);
-        console.log('Event sent successfully:', response.data);
+        await storePatient(patient);
+        console.log('Patient stored locally');
     } catch (error) {
-        console.error('Error sending event:', error);
+        console.error('Error storing patient:', error);
     }
 };

--- a/src/services/SessionApi.ts
+++ b/src/services/SessionApi.ts
@@ -1,0 +1,63 @@
+export interface LabResult {
+  id: string;
+  patientId: string;
+  result: string;
+  registeredAt: number;
+}
+
+export interface Patient {
+  id: string;
+  name: string;
+  dateOfBirth: any;
+  emailFromPatient?: string;
+  email?: string;
+  phoneNumber: string;
+}
+
+const LAB_RESULTS_KEY = 'labResults';
+const PATIENTS_KEY = 'patients';
+
+function read<T>(key: string): T[] {
+  const data = sessionStorage.getItem(key);
+  try {
+    return data ? JSON.parse(data) : [];
+  } catch {
+    return [];
+  }
+}
+
+function write<T>(key: string, data: T[]): void {
+  sessionStorage.setItem(key, JSON.stringify(data));
+}
+
+export async function storeLabResult(event: LabResult): Promise<void> {
+  const results = read<LabResult>(LAB_RESULTS_KEY);
+  results.push(event);
+  write(LAB_RESULTS_KEY, results);
+}
+
+export async function storePatient(patient: Patient): Promise<void> {
+  const patients = read<Patient>(PATIENTS_KEY);
+  patients.push(patient);
+  write(PATIENTS_KEY, patients);
+}
+
+export async function getLabResultsByPatient(patientId: string): Promise<LabResult[]> {
+  const results = read<LabResult>(LAB_RESULTS_KEY);
+  return results.filter(r => r.patientId === patientId);
+}
+
+export async function getLabResultById(id: string): Promise<LabResult[]> {
+  const results = read<LabResult>(LAB_RESULTS_KEY);
+  return results.filter(r => r.id === id);
+}
+
+export async function getAllLabResults(): Promise<string[]> {
+  const results = read<LabResult>(LAB_RESULTS_KEY);
+  return results.map(r => JSON.stringify(r));
+}
+
+export async function getAllPatients(): Promise<string[]> {
+  const patients = read<Patient>(PATIENTS_KEY);
+  return patients.map(p => JSON.stringify(p));
+}

--- a/src/views/Dashboard.tsx
+++ b/src/views/Dashboard.tsx
@@ -15,6 +15,7 @@ import {
 import { Bar } from 'react-chartjs-2';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { countOccurrencesResult } from '../utils/utils';
+import {getAllLabResults} from '../services/SessionApi';
 
 interface CounterProps {
     label: string;
@@ -72,13 +73,7 @@ const Dashboard: React.FC = () => {
 
     const fetchData = async () => {
         try {
-            const response = await fetch(`${process.env.REACT_APP_LABRESULT_BASE_URL}/labresult/allevents`);
-
-            if (!response.ok) {
-                throw new Error('Failed to fetch data');
-            }
-
-            const rawData: string[] = await response.json();
+            const rawData: string[] = await getAllLabResults();
 
             if (!rawData || !Array.isArray(rawData)) {
                 throw new Error('Invalid response format');

--- a/src/views/DashboardForPatient.tsx
+++ b/src/views/DashboardForPatient.tsx
@@ -16,6 +16,7 @@ import { Bar } from 'react-chartjs-2';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { countOccurrencesResult } from '../utils/utils';
 import {useAuthState} from "../authentication/auth";
+import {getLabResultsByPatient} from '../services/SessionApi';
 
 interface CounterProps {
     label: string;
@@ -89,13 +90,7 @@ const Dashboard: React.FC = () => {
                 console.log('dbUser is not available yet');
                 return;
             }
-            const response = await fetch(`${process.env.REACT_APP_LABRESULT_BASE_URL}/labresult/byPatient/${dbUser.firstName}`);
-
-            if (!response.ok) {
-                throw new Error('Failed to fetch data');
-            }
-
-            const rawData: LabResult[] = await response.json();
+            const rawData: LabResult[] = await getLabResultsByPatient(dbUser.firstName);
 
             if (!rawData || !Array.isArray(rawData)) {
                 throw new Error('Invalid response format');

--- a/src/views/HealthEvents.tsx
+++ b/src/views/HealthEvents.tsx
@@ -3,6 +3,7 @@ import DataTable, {TableColumn} from 'react-data-table-component';
 import {Link} from "react-router-dom";
 import '../styles/DataTable.css'
 import '../styles/expandable-events-row.css'
+import {getAllLabResults} from '../services/SessionApi';
 
 
 interface Event {
@@ -21,34 +22,27 @@ const EventList: React.FC = () => {
     useEffect(() => {
         const fetchData = async () => {
             try {
-                const response = await fetch(`${process.env.REACT_APP_LABRESULT_BASE_URL}/labresult/allevents`);
-
-                if (!response.ok) {
-                    throw new Error('Failed to fetch data');
-                }
-
-                const rawData: string[] = await response.json();
+                const rawData: string[] = await getAllLabResults();
 
                 if (!rawData || !Array.isArray(rawData)) {
                     throw new Error('Invalid response format');
                 }
 
-                // Parse the received strings into an array of Event objects
-                const parsedData = rawData.map((str, index) => {
-                    try {
-                        // Parse the raw string and then parse the inner JSON
-                        return JSON.parse(str);
-                    } catch (parseError) {
-                        if (parseError instanceof Error)
-                            console.error(`Error parsing JSON at index ${index}:`, parseError.message);
-                        console.log('Raw JSON string:', str); // Print the raw string for debugging
-                        return null; // or handle the error as needed
-                    }
-                }).filter(item => item !== null);
+                const parsedData = rawData
+                    .map((str, index) => {
+                        try {
+                            return JSON.parse(str);
+                        } catch (parseError) {
+                            if (parseError instanceof Error)
+                                console.error(`Error parsing JSON at index ${index}:`, parseError.message);
+                            console.log('Raw JSON string:', str);
+                            return null;
+                        }
+                    })
+                    .filter(item => item !== null);
                 setEvents(parsedData);
             } catch (error) {
-                if (error instanceof Error)
-                    console.error('Error fetching data:', error.message);
+                if (error instanceof Error) console.error('Error fetching data:', error.message);
             }
         };
 

--- a/src/views/HealthEventsForPatient.tsx
+++ b/src/views/HealthEventsForPatient.tsx
@@ -4,6 +4,7 @@ import {Link} from "react-router-dom";
 import '../styles/DataTable.css'
 import '../styles/expandable-events-row.css'
 import {useAuthState} from "../authentication/auth";
+import {getLabResultsByPatient} from '../services/SessionApi';
 
 
 interface Event {
@@ -37,13 +38,7 @@ const EventList: React.FC = () => {
                     return;
                 }
 
-                const response = await fetch(`${process.env.REACT_APP_LABRESULT_BASE_URL}/labresult/byPatient/${dbUser.name}`);
-
-                if (!response.ok) {
-                    throw new Error('Failed to fetch data');
-                }
-
-                const rawData: LabResult[] = await response.json();
+                const rawData: LabResult[] = await getLabResultsByPatient(dbUser.name);
 
                 if (!rawData || !Array.isArray(rawData)) {
                     throw new Error('Invalid response format');

--- a/src/views/[health-events]/page.tsx
+++ b/src/views/[health-events]/page.tsx
@@ -3,7 +3,7 @@ import {useParams} from 'react-router-dom';
 import "../../styles/home.css"
 
 import {Card, Typography, Button, Select, notification} from 'antd';
-import axios from 'axios';
+import {getLabResultById} from '../../services/SessionApi';
 
 const {Title, Paragraph} = Typography;
 const {Option} = Select;
@@ -29,21 +29,13 @@ const DetailedLabResult: React.FC = () => {
         // Fetch patients from your API and update the state
         const fetchLabResult = async () => {
             try {
-                //const response = await axios.get('http://localhost:8083/patients/events');
-                const response = await fetch(`${process.env.REACT_APP_LABRESULT_BASE_URL}/labresult/byLabId/${id}`);
-                if (!response.ok) {
-                    throw new Error('Failed to fetch data');
-                }
-
-                const rawData: Event[] = await response.json();
+                const rawData: Event[] = await getLabResultById(id as string);
 
                 if (!rawData || !Array.isArray(rawData) || rawData.length === 0) {
                     throw new Error('Invalid response format');
                 }
 
                 const parsedData: Event = rawData[0];
-                console.log(parsedData);
-
                 setEvent(parsedData);
             } catch (error) {
                 console.error('Error fetching patients:', error);

--- a/src/views/[users]/page.tsx
+++ b/src/views/[users]/page.tsx
@@ -8,7 +8,7 @@ import {
     updateUserWithPatientInfo
 } from "../../authentication/auth";
 import {Card, Typography, Button, Select, notification} from 'antd';
-import axios from 'axios';
+import {getAllPatients} from '../../services/SessionApi';
 
 const {Title, Paragraph} = Typography;
 const {Option} = Select;
@@ -53,13 +53,7 @@ const UserProfile: React.FC = () => {
         // Fetch patients from your API and update the state
         const fetchPatients = async () => {
             try {
-                //const response = await axios.get('http://localhost:8083/patients/events');
-                const response = await fetch(`${process.env.REACT_APP_PATIENT_BASE_URL}/patients/events`);
-                if (!response.ok) {
-                    throw new Error('Failed to fetch data');
-                }
-
-                const rawData: string[] = await response.json();
+                const rawData: string[] = await getAllPatients();
 
                 if (!rawData || !Array.isArray(rawData)) {
                     throw new Error('Invalid response format');

--- a/src/views/[users]/pageForDoctor.tsx
+++ b/src/views/[users]/pageForDoctor.tsx
@@ -8,7 +8,7 @@ import {
     updateUserWithPatientInfo, useAuthState
 } from "../../authentication/auth";
 import {Card, Typography, Button, Select, notification} from 'antd';
-import axios from 'axios';
+import {getLabResultsByPatient, getAllPatients} from '../../services/SessionApi';
 
 const {Title, Paragraph} = Typography;
 const {Option} = Select;
@@ -70,13 +70,7 @@ const UserProfileForDoctor: React.FC = () => {
                     return;
                 }
 
-                const response = await fetch(`${process.env.REACT_APP_LABRESULT_BASE_URL}/labresult/byPatient/${user?.name}`);
-
-                if (!response.ok) {
-                    throw new Error('Failed to fetch data');
-                }
-
-                const rawData: LabResult[] = await response.json();
+                const rawData: LabResult[] = await getLabResultsByPatient(user?.name as string);
 
                 if (!rawData || !Array.isArray(rawData)) {
                     throw new Error('Invalid response format');
@@ -146,13 +140,7 @@ const UserProfileForDoctor: React.FC = () => {
         // Fetch patients from your API and update the state
         const fetchPatients = async () => {
             try {
-                //const response = await axios.get('http://localhost:8083/patients/events');
-                const response = await fetch(`${process.env.REACT_APP_PATIENT_BASE_URL}/patients/events`);
-                if (!response.ok) {
-                    throw new Error('Failed to fetch data');
-                }
-
-                const rawData: string[] = await response.json();
+                const rawData: string[] = await getAllPatients();
 
                 if (!rawData || !Array.isArray(rawData)) {
                     throw new Error('Invalid response format');


### PR DESCRIPTION
## Summary
- store lab results and patients in session storage
- replace network requests with local session storage lookups
- remove unused axios imports

## Testing
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_684e8768b9f08333ab2647da3604efe4